### PR TITLE
patch for outline in v0.13.0

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -58,17 +58,13 @@
   set heading(numbering: heading-numbering)
   set enum(indent: enum-indent)
   set list(indent: list-indent)
-  show link: it => text(fill: blue.darken(20%), it)
-  set outline(indent: auto)
-  show outline.entry.where(
-    level: 1,
-  ): it => {
-    v(15pt, weak: true)
-    text(size: 11pt, [
-      #strong(it.body)
-      #box(width: 1fr, repeat[])
-      #strong(it.page)
-    ])}
+  show outline.entry.where(level:1): {
+    it => link(
+      it.element.location(),
+      it.indented(strong(it.prefix()), strong((it.body()) + h(1fr) + it.page()), 
+      gap:0.5em),
+    )
+  }
     // Referencing Figures
 
     show figure.where(kind: table): set figure(supplement: [Tab.], numbering: "1") if lang == "de"


### PR DESCRIPTION
As typst v0.13.0 is very young still, it seems that some distros do not have that problem with the outline. This PR will therefore be delayed until it works locally.